### PR TITLE
Update Gradle version to 8.7 for Java 21 support.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Running CurseForgeGradle with the previous settings (`7.4.2`) with Java 21 throws `java.lang.IllegalArgumentException: Unsupported class file major version 65`.

Updating gradle to 8.7 makes it compatible with Java 21, used in Minecraft 1.20.5. Up provided the solution via Discord :)