### PR TITLE
Support Gradle's Configuration Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,25 @@ buildscript {
 This plugin uses a task based approach to uploading files. Projects define a new task in their build script that will publish various files when invoked. The following example demonstrates how a Java based project would upload their main JAR.
 
 ```groovy
-task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+tasks.register('publishCurseForge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
 
     // This token is used to authenticate with CurseForge. It should be handled
     // with the same level of care and security as your actual password. You 
     // should never share your token with an untrusted source or publish it
     // publicly to GitHub or embed it within a project. The best practice is to
     // store this token in an environment variable or a build secret.
-    apiToken = findProperty('curseforge_token')
+    apiToken.set(project.providers.gradleProperty('curseforge_token'))
     
     // A project ID is required to tell CurseForge which project the uploaded
     // file belongs to. This is public on your project page and is not private
     // information.
-    projectId = findProperty('curseforge_project')
+    def projectId = findProperty('curseforge_project')
 
     // Tells CurseForgeGradle to publish the output of the jar task. This will
     // return a UploadArtifact object that can be used to further configure the
     // file. 
     def mainFile = upload(projectId, jar)
-    mainFile.changelog = 'The changelog string for this file.'
+    mainFile.changelog.set('The changelog string for this file.')
 }
 ```
 
@@ -65,7 +65,7 @@ task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge)
 Various examples for using CurseForgeGradle can be found [here](https://github.com/Darkhax/CurseForgeGradle/tree/main/examples/local_test_forge). 
 
 ### Automatic Version Detection
-In some cases CurseForgeGradle will be able to automatically detect version tags from context clues in your build environment. This can be useful if you don't want to define them manually however the results may not be perfect. This can be disabled using `disableVersionDetection()` within the body of your CurseForgeGradle task.
+In some cases CurseForgeGradle will be able to automatically detect version tags from context clues in your build environment. To make use of this use `TaskPublishWithDetection` instead of `TaskPublishCurseForge`. This can be useful if you don't want to define them manually however the results may not be perfect, and does not currently support Gradle's Configuration Cache.
 
 #### Minecraft
 The following versions are detected when using CurseForgeGradle in a Minecraft project.
@@ -78,21 +78,20 @@ The following versions are detected when using CurseForgeGradle in a Minecraft p
 The following properties and methods are exposed for use within your script.
 
 #### TaskPublishCurseForge
-| Name                      | Accepted Type          | Description                                                                                                                                                                                                                                                                                                                                                    |
-|---------------------------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| apiToken                  | String\|File\|Closure  | The API token used to authenticate with CurseForge. Setting this property is required to use this plugin.                                                                                                                                                                                                                                                      |
-| apiEndpoint               | String\|File\|Closure  | The API endpoint to upload the file to. This is an optional property and will default to the Minecraft API.                                                                                                                                                                                                                                                    |
-| debugMode                 | Boolean                | Determines if publishing should actually happen or if the request should just be logged instead. This is an optional property and will default to false.                                                                                                                                                                                                       |
+| Name                      | Accepted Type          | Description                                                                                                                                                                                                                                                                                                                                                              |
+|---------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| apiToken                  | String                 | The API token used to authenticate with CurseForge. Setting this property is required to use this plugin.                                                                                                                                                                                                                                                                |
+| apiEndpoint               | String                 | The API endpoint to upload the file to. This is an optional property and will default to the Minecraft API.                                                                                                                                                                                                                                                              |
+| debugMode                 | Boolean                | Determines if publishing should actually happen or if the request should just be logged instead. This is an optional property and will default to false.                                                                                                                                                                                                                 |
 | upload(projectId, file)   | String\|Number, Object | Invoking this method will configure the task to upload a given file to a given project. The projectId can be a valid numeric String or any valid number. The file can be a file reference, an AbstractArchiveTask, or any other object Gradle can resolve as a file. This returns an UploadArtifact object which can be used to configure the file before publishing it. |
-| disableVersionDetection() |                        | Invoking this method will disable automatic version detection for all files uploaded by this instance of the task.                                                                                                                                                                                                                                             |
 
 #### UploadArtifact
 | Name                            | Accepted Type                                     | Description                                                                                                                                                                                |
 |---------------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| changelog                       | String\|File\|Closure                             | The changelog for the file. This is optional.                                                                                                                                              |
-| changelogType                   | String\|File\|Closure                             | The formatting type of the changelog. The default is plaintext but html and markdown are also accepted.                                                                                    |
-| displayName                     | String\|File\|Closure                             | An optional display name that will visually replace the file name. Using this method is often discouraged.                                                                                 |
-| releaseType                     | String\|File\|Closure                             | The type of release you are publishing. This accepts alpha, beta, and release. The default is alpha.                                                                                       |
+| changelog                       | String                                            | The changelog for the file. This is optional.                                                                                                                                              |
+| changelogType                   | String                                            | The formatting type of the changelog. The default is plaintext but html and markdown are also accepted.                                                                                    |
+| displayName                     | String                                            | An optional display name that will visually replace the file name. Using this method is often discouraged.                                                                                 |
+| releaseType                     | String                                            | The type of release you are publishing. This accepts alpha, beta, and release. The default is alpha.                                                                                       |
 | addIncompatibility(slugs...)    | String\|File\|Closure, ...                        | Marks the file as being incompatible with the specified project(s).                                                                                                                        |
 | addRequirement(slugs...)        | String\|File\|Closure, ...                        | Marks the file as requiring a file from the specified project(s).                                                                                                                          |
 | addEmbedded(slugs...)           | String\|File\|Closure, ...                        | Marks the file as containing an embedded implementation of another project(s).                                                                                                             |

--- a/examples/local_test_forge/build.gradle
+++ b/examples/local_test_forge/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 
 version = "1.0.${Math.abs(new Random().nextInt())}"
-archivesBaseName = 'CurseForgeGradle-TEST'
+project.base.archivesName = 'CurseForgeGradle-TEST'
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(16)
 java.withSourcesJar()
@@ -39,23 +39,23 @@ dependencies {
 jar.finalizedBy('reobfJar')
 
 // CurseForgeGradle
-task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+tasks.register('publishCurseForge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
 
-    apiToken = curseforgegradle_testtoken
+    apiToken.set(curseforgegradle_testtoken)
 
     // The main file to upload
     def mainFile = upload(537663, jar)
-    mainFile.releaseType = 'beta'
-    mainFile.changelog = 'This is a test file. Please ignore it. The mod does nothing.'
-    mainFile.changelogType = 'markdown'
+    mainFile.releaseType.set('beta')
+    mainFile.changelog.set('This is a test file. Please ignore it. The mod does nothing.')
+    mainFile.changelogType.set('markdown')
     mainFile.addIncompatibility('bookshelf')
 
     // The sources JAR
     def sourcesFile = mainFile.withAdditionalFile(sourcesJar)
-    sourcesFile.changelog = file('changelog.md')
+    sourcesFile.changelog.set(project.layout.buildDirectory.file('changelog.md').map(file -> file.asFile.text))
 
     // The JavaDoc JAR
     def javadocFile = mainFile.withAdditionalFile(javadocJar)
-    javadocFile.changelog = 'This is a test JavaDoc file!'
-    javadocFile.displayName = "JavaDoc - ${version}"
+    javadocFile.changelog.set('This is a test JavaDoc file!')
+    javadocFile.displayName.set("JavaDoc - ${version}")
 }

--- a/examples/multiloader_example/Common/build.gradle
+++ b/examples/multiloader_example/Common/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.darkhax.curseforgegradle' version '0.2.6'
 }
 
-archivesBaseName = "${mod_name}-common-${minecraft_version}"
+project.base.archivesName = "${mod_name}-common-${minecraft_version}"
 
 minecraft {
     version(minecraft_version)
@@ -25,14 +25,14 @@ dependencies {
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.4'
 }
 
-task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+tasks.register('publishCurseForge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
 
     description = 'publishes the common build to CurseForge.'
 
-    apiToken = curseforgegradle_testtoken
+    apiToken.set(curseforgegradle_testtoken)
 
     def mainFile = upload(537663, jar)
-    mainFile.changelog = 'This is a test file. It was compiled against the vanilla game.'
+    mainFile.changelog.set('This is a test file. It was compiled against the vanilla game.')
     def sourcesFile = mainFile.withAdditionalFile(sourcesJar)
     def javadocFile = mainFile.withAdditionalFile(javadocJar)
 }

--- a/examples/multiloader_example/Fabric/build.gradle
+++ b/examples/multiloader_example/Fabric/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'net.darkhax.curseforgegradle' version '0.2.6'
 }
 
-archivesBaseName = "${mod_name}-fabric-${minecraft_version}"
+project.base.archivesName = "${mod_name}-fabric-${minecraft_version}"
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
@@ -68,14 +68,14 @@ publishing {
     }
 }
 
-task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+tasks.register('publishCurseForge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
 
     description = 'publishes the commob build to CurseForge.'
 
-    apiToken = curseforgegradle_testtoken
+    apiToken.set(curseforgegradle_testtoken)
 
-    def mainFile = upload(537663, file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar"))
-    mainFile.changelog = 'This is a test file. It was compiled against Fabric.'
+    def mainFile = upload(537663, project.layout.buildDirectory.file("libs/${project.base.archivesName.get()}-${version}.jar"))
+    mainFile.changelog.set('This is a test file. It was compiled against Fabric.')
     def sourcesFile = mainFile.withAdditionalFile(sourcesJar)
     def javadocFile = mainFile.withAdditionalFile(javadocJar)
 }

--- a/examples/multiloader_example/Forge/build.gradle
+++ b/examples/multiloader_example/Forge/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-archivesBaseName = "${mod_name}-forge-${minecraft_version}"
+project.base.archivesName = "${mod_name}-forge-${minecraft_version}"
 
 minecraft {
 
@@ -100,14 +100,14 @@ publishing {
     }
 }
 
-task publishCurseForge(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
+tasks.register('publishCurseForge', net.darkhax.curseforgegradle.TaskPublishCurseForge) {
 
     description = 'publishes the commob build to CurseForge.'
 
-    apiToken = curseforgegradle_testtoken
+    apiToken.set(curseforgegradle_testtoken)
 
     def mainFile = upload(537663, jar)
-    mainFile.changelog = 'This is a test file. It was compiled against Forge.'
+    mainFile.changelog.set('This is a test file. It was compiled against Forge.')
     def sourcesFile = mainFile.withAdditionalFile(sourcesJar)
     def javadocFile = mainFile.withAdditionalFile(javadocJar)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
 group=net.darkhax.curseforgegradle
-version=1.1
+version=1.2
 archiveBaseName=CurseForgeGradle
 description=Gradle plugin for uploading files to CurseForge projects.
 vendor=Darkhax

--- a/src/main/java/net/darkhax/curseforgegradle/TaskPublishWithDetection.java
+++ b/src/main/java/net/darkhax/curseforgegradle/TaskPublishWithDetection.java
@@ -1,0 +1,53 @@
+package net.darkhax.curseforgegradle;
+
+//TODO: Eventually try to figure out how to make the Version detector support the configuration cache
+// and then remove this task merging the optional version detection back into the base task type
+public abstract class TaskPublishWithDetection extends TaskPublishCurseForge {
+
+    /**
+     * Handles the automatic discovery of game version tags from variables in the Gradle environment. If this is not
+     * disabled detected versions will be applied in {@link #initialize()}.
+     */
+    private final VersionDetector versionDetector;
+
+    /**
+     * This task should not be constructed manually. It will be constructed dynamically by Gradle when a user defines
+     * the task. Code inside the constructor will be executed before the user configuration.
+     */
+    public TaskPublishWithDetection() {
+
+        this.versionDetector = new VersionDetector(this.getProject(), this.log);
+        notCompatibleWithConfigurationCache("Version detection does not currently support the configuration cache");
+    }
+
+    /**
+     * Disables automatic version detection for all artifacts published through the current task. Prefer just using TaskPublishCurseForge over calling this method.
+     */
+    public void disableVersionDetection() {
+
+        this.versionDetector.isEnabled = false;
+    }
+
+    /**
+     * Validates the task configuration and sets up data required for publishing artifacts.
+     */
+    @Override
+    protected void initialize() {
+
+        super.initialize();
+
+        // Handle auto version detection.
+        if (this.versionDetector.isEnabled) {
+
+            this.versionDetector.detectVersions(this.validGameVersions);
+
+            for (String detectedVersion : this.versionDetector.getDetectedVersions()) {
+
+                for (UploadArtifact artifact : getUploadArtifacts().get()) {
+
+                    artifact.addGameVersion(detectedVersion);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/darkhax/curseforgegradle/TaskPublishWithDetection.java
+++ b/src/main/java/net/darkhax/curseforgegradle/TaskPublishWithDetection.java
@@ -1,7 +1,14 @@
 package net.darkhax.curseforgegradle;
 
-//TODO: Eventually try to figure out how to make the Version detector support the configuration cache
-// and then remove this task merging the optional version detection back into the base task type
+/**
+ * A Gradle task that can publish multiple files to CurseForge. A project can define any number of these tasks, and any
+ * given task can be responsible for publishing any number of files to any number of projects.
+ *
+ * <p>
+ * Unlike the parent {@link TaskPublishCurseForge}, this task auto-detects versioning information for the current project. This task also
+ * does not currently support <a href="https://docs.gradle.org/current/userguide/configuration_cache.html">Gradle's configuration cache</a> system.
+ * </p>
+ */
 public abstract class TaskPublishWithDetection extends TaskPublishCurseForge {
 
     /**
@@ -17,15 +24,9 @@ public abstract class TaskPublishWithDetection extends TaskPublishCurseForge {
     public TaskPublishWithDetection() {
 
         this.versionDetector = new VersionDetector(this.getProject(), this.log);
+        //TODO: Eventually try to figure out how to make the Version detector support the configuration cache
+        // and then remove this task merging the optional version detection back into the base task type
         notCompatibleWithConfigurationCache("Version detection does not currently support the configuration cache");
-    }
-
-    /**
-     * Disables automatic version detection for all artifacts published through the current task. Prefer just using TaskPublishCurseForge over calling this method.
-     */
-    public void disableVersionDetection() {
-
-        this.versionDetector.isEnabled = false;
     }
 
     /**
@@ -37,16 +38,13 @@ public abstract class TaskPublishWithDetection extends TaskPublishCurseForge {
         super.initialize();
 
         // Handle auto version detection.
-        if (this.versionDetector.isEnabled) {
+        this.versionDetector.detectVersions(this.validGameVersions);
 
-            this.versionDetector.detectVersions(this.validGameVersions);
+        for (String detectedVersion : this.versionDetector.getDetectedVersions()) {
 
-            for (String detectedVersion : this.versionDetector.getDetectedVersions()) {
+            for (UploadArtifact artifact : getUploadArtifacts().get()) {
 
-                for (UploadArtifact artifact : getUploadArtifacts().get()) {
-
-                    artifact.addGameVersion(detectedVersion);
-                }
+                artifact.addGameVersion(detectedVersion);
             }
         }
     }

--- a/src/main/java/net/darkhax/curseforgegradle/UploadArtifact.java
+++ b/src/main/java/net/darkhax/curseforgegradle/UploadArtifact.java
@@ -128,53 +128,28 @@ public class UploadArtifact {
     // --- TASK PROPERTIES --- //
 
     /**
-     * An optional changelog for this file. This is displayed on the CurseForge website, and it's use is highly
-     * recommended. For best results this should be defined using a UTF-8 string.
-     * <p>
-     * When a sub file is created using {@link #withAdditionalFile(Object)} it will inherit the current changelog value.
-     * This can still be changed independently after creation.
+     * @see #getChangelog()
      */
-    @Input
-    @Optional
     private final Property<String> changelog;
 
     /**
-     * The type of changelog being defined. CurseForge supports various formats such as markdown and HTML however the
-     * default format is plaintext.
-     * <p>
-     * When a sub file is created using {@link #withAdditionalFile(Object)} it will inherit the current changelog type.
-     * This can still be changed independently after creation.
+     * @see #getChangelogType()
      */
-    @Input
     private final Property<String> changelogType;
 
     /**
-     * The display name for the file on CurseForge. When defined this will hide the name of the file on CurseForge. The
-     * use of this property is generally discouraged.
+     * @see #getDisplayName()
      */
-    @Input
-    @Optional
     private final Property<String> displayName;
 
     /**
-     * A set of game versions associated with the artifact. At least one game version is required to upload an artifact.
-     * Additional meta tags like Java version or Loader version are also considered game versions by CurseForge and are
-     * added here.
-     * <p>
-     * Sub files automatically inherit the game versions of their parent file. This is a hard limit enforced by the
-     * CurseForge API and can not be changed after the fact.
+     * @see #getGameVersions()
      */
-    @Input
     private final SetProperty<String> gameVersions;
 
     /**
-     * The type of release for this file. The default release type is an alpha. When using something like CI to automate
-     * bleeding edge releases it is recommended to retain the alpha release type.
-     * <p>
-     * When a sub file is created using {@link #withAdditionalFile(Object)} it will inherit the current release type.
-     * This can still be changed independently after creation.
+     * @see #getReleaseType()
      */
-    @Input
     private final Property<String> releaseType;
 
     /**
@@ -209,28 +184,74 @@ public class UploadArtifact {
         this.artifact = artifactContainer;
     }
 
+    /**
+     * An optional changelog for this file. This is displayed on the CurseForge website, and it's use is highly
+     * recommended. For best results this should be defined using a UTF-8 string.
+     * <p>
+     * When a sub file is created using {@link #withAdditionalFile(Object)} it will inherit the current changelog value.
+     * This can still be changed independently after creation.
+     */
+    @Input
+    @Optional
     public Property<String> getChangelog() {
+
         return changelog;
     }
 
+    /**
+     * The type of changelog being defined. CurseForge supports various formats such as markdown and HTML however the
+     * default format is plaintext.
+     * <p>
+     * When a sub file is created using {@link #withAdditionalFile(Object)} it will inherit the current changelog type.
+     * This can still be changed independently after creation.
+     */
+    @Input
     public Property<String> getChangelogType() {
+
         return changelogType;
     }
 
+    /**
+     * The display name for the file on CurseForge. When defined this will hide the name of the file on CurseForge. The
+     * use of this property is generally discouraged.
+     */
+    @Input
+    @Optional
     public Property<String> getDisplayName() {
+
         return displayName;
     }
 
+    /**
+     * The type of release for this file. The default release type is an alpha. When using something like CI to automate
+     * bleeding edge releases it is recommended to retain the alpha release type.
+     * <p>
+     * When a sub file is created using {@link #withAdditionalFile(Object)} it will inherit the current release type.
+     * This can still be changed independently after creation.
+     */
+    @Input
     public Property<String> getReleaseType() {
+
         return releaseType;
     }
 
+    /**
+     * A set of game versions associated with the artifact. At least one game version is required to upload an artifact.
+     * Additional meta tags like Java version or Loader version are also considered game versions by CurseForge and are
+     * added here.
+     * <p>
+     * Sub files automatically inherit the game versions of their parent file. This is a hard limit enforced by the
+     * CurseForge API and can not be changed after the fact.
+     */
+    @Input
     public SetProperty<String> getGameVersions() {
+
         return gameVersions;
     }
 
     @InputFiles
     public FileCollection getArtifact() {
+
         return artifact;
     }
 
@@ -338,6 +359,7 @@ public class UploadArtifact {
      * @param environments The supported environments.
      */
     public void addEnvironment(Object... environments) {
+
         addGameVersion(environments);
     }
 
@@ -632,6 +654,7 @@ public class UploadArtifact {
 
     @Nullable
     public Long getCurseFileId() {
+
         return curseFileId;
     }
 }

--- a/src/main/java/net/darkhax/curseforgegradle/VersionDetector.java
+++ b/src/main/java/net/darkhax/curseforgegradle/VersionDetector.java
@@ -35,11 +35,6 @@ public final class VersionDetector {
     private final Set<String> detectedVersions = new HashSet<>();
 
     /**
-     * A flag that determines if the auto-detection is enabled. This can be disabled with user configs.
-     */
-    public boolean isEnabled = true;
-
-    /**
      * The version detector should not be constructed manually. It is automatically constructed when the CurseForge
      * publish task is defined. Each task will have its own instance of the version detector.
      *
@@ -54,33 +49,30 @@ public final class VersionDetector {
     }
 
     /**
-     * Initiates the detection of game versions. If {@link #isEnabled} is false this will not run.
+     * Initiates the detection of game versions.
      *
      * @param validGameVersions Valid game versions for the current game.
      */
     public void detectVersions(GameVersions validGameVersions) {
 
-        if (isEnabled) {
+        // Minecraft
 
-            // Minecraft
+        // Detect ModLoader versions.
+        detectPlugin(validGameVersions, "net.minecraftforge.gradle", "Forge");
+        detectPlugin(validGameVersions, "fabric-loom", "Fabric");
+        detectPlugin(validGameVersions, "org.quiltmc.loom", "Quilt");
+        detectPlugin(validGameVersions, "net.neoforged.gradle", "NeoForge");
+        detectPlugin(validGameVersions, "net.neoforged.gradle.userdev", "NeoForge");
 
-            // Detect ModLoader versions.
-            detectPlugin(validGameVersions, "net.minecraftforge.gradle", "Forge");
-            detectPlugin(validGameVersions, "fabric-loom", "Fabric");
-            detectPlugin(validGameVersions, "org.quiltmc.loom", "Quilt");
-            detectPlugin(validGameVersions, "net.neoforged.gradle", "NeoForge");
-            detectPlugin(validGameVersions, "net.neoforged.gradle.userdev", "NeoForge");
+        // Detect Minecraft versions.
+        detectProperty(validGameVersions, "MC_VERSION");
+        detectProperty(validGameVersions, "minecraft_version");
+        detectProperty(validGameVersions, "mc_version");
+        detectProperty(validGameVersions, "mcVersion");
+        detectProperty(validGameVersions, "minecraftVersion");
 
-            // Detect Minecraft versions.
-            detectProperty(validGameVersions, "MC_VERSION");
-            detectProperty(validGameVersions, "minecraft_version");
-            detectProperty(validGameVersions, "mc_version");
-            detectProperty(validGameVersions, "mcVersion");
-            detectProperty(validGameVersions, "minecraftVersion");
-
-            // Detect Java versions.
-            detectJavaToolchainVersion(validGameVersions);
-        }
+        // Detect Java versions.
+        detectJavaToolchainVersion(validGameVersions);
     }
 
     /**


### PR DESCRIPTION
- Makes a handful of breaking changes moving things over to using gradle's properties to allow for lazy configuration of certain settings
- Replace a few usages of `getProject` in `TaskPublishCurseForge` with alternatives that are supported by the [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html)
- Split the version detection into a secondary subtask, as I am not sure how to go about adjusting that to support the config cache, and marked this second task as not being compatible with the configuration cache so that it won't crash on people if they try to run it with the configuration cache enabled