### PR TITLE
Add support for lazy configuration and config-cache

### DIFF
--- a/src/main/java/net/darkhax/curseforgegradle/VersionDetector.java
+++ b/src/main/java/net/darkhax/curseforgegradle/VersionDetector.java
@@ -1,15 +1,17 @@
 package net.darkhax.curseforgegradle;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import net.darkhax.curseforgegradle.api.versions.GameVersions;
+import org.apache.groovy.util.Maps;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 /**
@@ -19,9 +21,23 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
 public final class VersionDetector {
 
     /**
-     * The project that this detector is attached to. This is used for finding applied plugins or properties.
+     * A map of well known plugins and the versions they are associated with. This is used to automatically detect them.
      */
-    private final Project project;
+    private static final Map<String, String> WELL_KNOWN_PLUGINS = Maps.of(
+            "net.minecraftforge.gradle", "Forge",
+            "fabric-loom", "Fabric",
+            "org.quiltmc.loom", "Quilt",
+            "net.neoforged.gradle", "NeoForge",
+            "net.neoforged.gradle.userdev", "NeoForge"
+    );
+
+    private static final Set<String> WELL_KNOWN_PROPERTIES = Sets.newHashSet(
+            "MC_VERSION",
+            "minecraft_version",
+            "mc_version",
+            "mcVersion",
+            "minecraftVersion"
+    );
 
     /**
      * The debug logger for the detector. When a new version is detected it will be logged to help debug things in the
@@ -40,6 +56,18 @@ public final class VersionDetector {
     public boolean isEnabled = true;
 
     /**
+     * A set of detected plugin versions. This detection is run lazily and when the task that owns this detector
+     * initializes during task execution is it queried to register versions.
+     */
+    private final Map<String, String> detectedPluginVersions = new HashMap<>();
+
+    /**
+     * A set of detected properties. This detection is run lazily and when the task that owns this detector
+     * initializes during task execution is it queried to register versions.
+     */
+    private final Map<String, Provider<String>> detectedProperties = new HashMap<>();
+
+    /**
      * The version detector should not be constructed manually. It is automatically constructed when the CurseForge
      * publish task is defined. Each task will have its own instance of the version detector.
      *
@@ -48,9 +76,45 @@ public final class VersionDetector {
      * @param log     The log output for debug information. This is taken from the task that owns this instance.
      */
     VersionDetector(Project project, Logger log) {
-
-        this.project = project;
         this.log = log;
+
+        //This operates as a lazy detection mechanism.
+        //withId either executes immediately if the plugin is already applied or when the plugin is applied.
+        //We then read the detected versions during task execution.
+        WELL_KNOWN_PLUGINS.forEach((pluginName, version) -> {
+            project.getPlugins().withId(pluginName, plugin -> {
+                detectedPluginVersions.put(pluginName, version);
+            });
+        });
+
+        //This operates as a lazy detection mechanism.
+        //We then read the detected versions during task execution.
+        WELL_KNOWN_PROPERTIES.forEach(propertyName -> {
+            //This is a bit of a weird way to do it, but it is the only way to get the property value lazily.
+            //We can't just use project.findProperty because it will throw an exception if the property is not found.
+            //And we can not call it during task execution as we are not allowed to use or store the project.
+            //So the best alternative is to use a provider that will lazily evaluate the property.
+            //And if it is not currently registered on task creation, we use a gradle property provider instead.
+            Provider<String> propertyProvider = project.hasProperty(propertyName) ?
+                    project.provider(() -> TaskPublishCurseForge.parseString(project.findProperty(propertyName))) :
+                    project.getProviders().gradleProperty(propertyName);
+
+            propertyProvider = propertyProvider.orElse("");
+
+            detectedProperties.put(propertyName, propertyProvider);
+        });
+
+        //Now we detect the java version from the java toolchain.
+        JavaPluginExtension extension = project.getExtensions().findByType(JavaPluginExtension.class);
+
+        if (extension !=  null) {
+            //We use a lazy resolve here as the java toolchain is not always available.
+            Property<JavaLanguageVersion> languageVersion = extension.getToolchain().getLanguageVersion();
+            detectedProperties.put("JavaVersion", languageVersion
+                            .map(JavaLanguageVersion::asInt)
+                            .filter(version -> version > 0)
+                            .map(version -> "Java " + version).orElse(""));
+        }
     }
 
     /**
@@ -65,21 +129,19 @@ public final class VersionDetector {
             // Minecraft
 
             // Detect ModLoader versions.
-            detectPlugin(validGameVersions, "net.minecraftforge.gradle", "Forge");
-            detectPlugin(validGameVersions, "fabric-loom", "Fabric");
-            detectPlugin(validGameVersions, "org.quiltmc.loom", "Quilt");
-            detectPlugin(validGameVersions, "net.neoforged.gradle", "NeoForge");
-            detectPlugin(validGameVersions, "net.neoforged.gradle.userdev", "NeoForge");
+            detectedPluginVersions.forEach((pluginName, version) -> {
+                if (addDetectedChecked(validGameVersions, version)) {
+                    this.log.debug("Detected plugin '{}'. Automatically applying version '{}'.", pluginName, version);
+                }
+            });
 
-            // Detect Minecraft versions.
-            detectProperty(validGameVersions, "MC_VERSION");
-            detectProperty(validGameVersions, "minecraft_version");
-            detectProperty(validGameVersions, "mc_version");
-            detectProperty(validGameVersions, "mcVersion");
-            detectProperty(validGameVersions, "minecraftVersion");
-
-            // Detect Java versions.
-            detectJavaToolchainVersion(validGameVersions);
+            // Detect properties (Which includes the java version)
+            detectedProperties.forEach((propertyName, provider) -> {
+                final String propertyValue = provider.get();
+                if (!propertyValue.isEmpty() && addDetectedChecked(validGameVersions, propertyValue)) {
+                    this.log.debug("Detected property '{}'. Automatically applying version '{}'.", propertyName, propertyValue);
+                }
+            });
         }
     }
 
@@ -108,54 +170,5 @@ public final class VersionDetector {
             return this.detectedVersions.add(version);
         }
         return false;
-    }
-
-    /**
-     * Applies a given game version if a Gradle plugin is applied within the same script.
-     *
-     * @param pluginName The name of the plugin to search for. This should be the same as the name used to apply the
-     *                   plugin.
-     * @param version    The version to apply if the plugin is detected.
-     */
-    private void detectPlugin(GameVersions validGameVersions, String pluginName, String version) {
-
-        if (project.getPlugins().hasPlugin(pluginName) && addDetectedChecked(validGameVersions, version)) {
-
-            this.log.debug("Detected plugin '{}'. Automatically applying version '{}'.", pluginName, version);
-        }
-    }
-
-    /**
-     * Applies a given property as a game version.
-     *
-     * @param propertyName The property name to read as a version.
-     */
-    private void detectProperty(GameVersions validGameVersions, String propertyName) {
-
-        final String propertyVersion = TaskPublishCurseForge.parseString(project.findProperty(propertyName));
-
-        if (propertyVersion != null && addDetectedChecked(validGameVersions, propertyVersion)) {
-
-            this.log.debug("Detected property '{}'. Automatically applying version '{}'.", propertyName, propertyVersion);
-        }
-    }
-
-    /**
-     * Attempts to detect the java version from the configured java tool chain.
-     */
-    private void detectJavaToolchainVersion(GameVersions validGameVersions) {
-
-        JavaPluginExtension extension = this.project.getExtensions().findByType(JavaPluginExtension.class);
-
-        if (extension !=  null) {
-
-            Property<JavaLanguageVersion> languageVersion = extension.getToolchain().getLanguageVersion();
-            int version = languageVersion.map(JavaLanguageVersion::asInt).getOrElse(0);
-
-            if (version > 0 && addDetectedChecked(validGameVersions, "Java " + version)) {
-
-                this.log.debug("Detected java version '{}'. Automatically applying version 'Java {}'.", version, version);
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR adds support for the configuration cache when publishing.

When the plugins task is currently used in a build that has the configuration cache enabled then the following error gets thrown: https://gist.github.com/marchermans/f4c08fefb1f38ab7efcdfee69384ce2b, as the error states this is because the task implementation does two things:
1) The version detector holds a reference to the project in a field
2) The task action calls for the project during execution, which is not supported when the configuration cache is used, because project configuration has not necessarily run.

To prevent these problems the VersionDetector now uses a lazy approach the detect the relevant version numbers (using Providers, or withId) to make sure it does not need to store a project for later configuration.

Secondly we now inject the ObjectFactory into the Task via @Inject and inject it directly into the GameVersions object, additionally we also pre-calculate the project displayname, which is during project evaluation already read-only, and as such can be trivially retrieved during task construction.